### PR TITLE
Add NuoCA to client package

### DIFF
--- a/client/artifact.py
+++ b/client/artifact.py
@@ -62,7 +62,11 @@ class GitHubMetadata(object):
         url = self.__METAURL.format(account, repo)
         self.metadata = json.loads(_getremotedata(url))
         self.version = self.metadata['name']
-        self.pkgurl = self.metadata['assets'][0]['browser_download_url']
+
+        if self.metadata['assets']:
+            self.pkgurl = self.metadata['assets'][0]['browser_download_url']
+        else:
+            self.pkgurl = self.metadata['zipball_url']
 
 
 class PyPIMetadata(object):

--- a/client/pkg/__init__.py
+++ b/client/pkg/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['nuodb', 'jdbc', 'migrator', 'hibernate', 'pynuodb', 'pynuoadmin']
+__all__ = ['nuodb', 'jdbc', 'migrator', 'hibernate', 'pynuodb', 'pynuoadmin', 'pynuoca']

--- a/client/pkg/pynuoadmin.py
+++ b/client/pkg/pynuoadmin.py
@@ -31,52 +31,27 @@ class PyNuoadminPackage(Package):
         return ['nuodb']
 
     def download(self):
-        # Find the latest release
-        pypi = PyPIMetadata('pynuoadmin')
-
-        self.setversion(pypi.version)
-
-        self._file = Artifact(self.name, 'pynuoadmin.tar.gz',
-                              pypi.pkgurl, chksum=pypi.pkgchksum)
-        self._file.update()
-
-        # Grab the latest version of argcomplete
-        acpypi = PyPIMetadata('argcomplete')
-        self._ac_version = acpypi.version
-        self._ac_file = Artifact('argcomplete',
-                                 'argcomplete-{}.tar.gz'.format(self._ac_version),
-                                 acpypi.pkgurl,
-                                 chksum=acpypi.pkgchksum)
-        self._ac_file.update()
+        pass
 
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
-        unpack_file(self._file.path, self.pkgroot)
-        self.stage.basedir = os.path.join(self.pkgroot, 'pynuoadmin-{}'.format(self.stage.version))
-
-        unpack_file(self._ac_file.path, self.pkgroot)
-        self.ac_basedir = os.path.join(self.pkgroot, 'argcomplete-{}'.format(self._ac_version))
+        run(['pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
 
     def install(self):
-        pdir = os.path.join('python', 'pynuoadmin')
-        self.stage.stage(pdir, ['nuodb_cli.py', 'nuodb_mgmt.py'])
-        self.stage.stage('doc', ['README.rst'])
-
-        acdir = os.path.join('python', 'argcomplete')
-        self.stage.stage(acdir, [os.path.join(self.ac_basedir, 'argcomplete/')])
-        self.stage.stage(acdir, [os.path.join(self.ac_basedir, 'LICENSE.rst')])
-
-        if Globals.target == 'lin64':
-            self.stage.stage('bin', [os.path.join(Globals.bindir, 'nuocmd')])
-            self.stage.stagefiles('etc', Globals.etcdir, ['run-java-app.sh', 'nuokeymgr'])
-        else:
-            self.stage.stage('bin', [os.path.join(Globals.bindir, 'nuocmd.bat')])
-            self.stage.stagefiles('etc', Globals.etcdir, ['nuokeymgr.bat'])
+        self.stage.stage('python', ['./'])
 
         nuodb = self.get_package('nuodb')
         self.stage.stage('jar', [os.path.join(nuodb.staged[0].basedir, 'jar', 'nuokeymanager.jar')])
-        self.stage.stage(pdir, [os.path.join(nuodb.staged[0].basedir, 'drivers', 'pynuoadmin', 'nuocmd-complete')])
+        self.stage.stage('python', [os.path.join(nuodb.staged[0].basedir, 'drivers', 'pynuoadmin', 'nuocmd-complete')])
+
+        if Globals.target == 'lin64':
+            self.stage.stage('bin', [os.path.join(nuodb.staged[0].basedir, 'bin', 'nuocmd')])
+            self.stage.stagefiles('etc', os.path.join(nuodb.staged[0].basedir, 'etc'), ['run-java-app.sh', 'nuokeymgr'])
+        else:
+            self.stage.stage('bin', [os.path.join(nuodb.staged[0].basedir, 'bin', 'nuocmd.bat')])
+            self.stage.stagefiles('etc', os.path.join(nuodb.staged[0].basedir, 'etc'), ['nuokeymgr.bat'])
+
 
 
 # Create and register this package

--- a/client/pkg/pynuoadmin.py
+++ b/client/pkg/pynuoadmin.py
@@ -6,8 +6,8 @@ import os
 
 from client.package import Package
 from client.stage import Stage
-from client.artifact import PyPIMetadata, Artifact
-from client.utils import *
+from client.utils import rmdir, mkdir, run, Globals
+
 
 class PyNuoadminPackage(Package):
     """Add the NuoDB pynuoadmin client."""
@@ -29,9 +29,6 @@ class PyNuoadminPackage(Package):
     def prereqs(self):
         # We need nuodb to get nuokeymanager.jar
         return ['nuodb']
-
-    def download(self):
-        pass
 
     def unpack(self):
         rmdir(self.pkgroot)

--- a/client/pkg/pynuoadmin.py
+++ b/client/pkg/pynuoadmin.py
@@ -4,6 +4,8 @@
 
 import os
 
+import sys
+
 from client.package import Package
 from client.stage import Stage
 from client.utils import rmdir, mkdir, run, Globals
@@ -33,7 +35,7 @@ class PyNuoadminPackage(Package):
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
-        run(['pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
+        run([sys.executable, 'pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
 
     def install(self):
         self.stage.stage('python', ['./'])

--- a/client/pkg/pynuoadmin.py
+++ b/client/pkg/pynuoadmin.py
@@ -4,11 +4,9 @@
 
 import os
 
-import sys
-
 from client.package import Package
 from client.stage import Stage
-from client.utils import rmdir, mkdir, run, Globals
+from client.utils import rmdir, mkdir, runpip, Globals
 
 
 class PyNuoadminPackage(Package):
@@ -35,7 +33,7 @@ class PyNuoadminPackage(Package):
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
-        run([sys.executable, 'pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
+        runpip(self.__PKGNAME, self.pkgroot)
 
     def install(self):
         self.stage.stage('python', ['./'])

--- a/client/pkg/pynuoca.py
+++ b/client/pkg/pynuoca.py
@@ -2,39 +2,14 @@
 #
 # Add the nuodb collection agent
 
-import os
-
 from client.package import Package
 from client.stage import Stage
-from client.artifact import PyPIMetadata, Artifact
-from client.utils import *
+from client.utils import rmdir, mkdir, run
 
 class PyNuoCA(Package):
     """Add the NuoDB Collection Agent"""
 
     __PKGNAME = 'pynuoca'
-
-    class PyDep:
-        _file = ""
-        _version = ""
-        _basedir = ""
-
-    dependencies = {'aenum': PyDep(),
-                    'click': PyDep(),
-                    'elasticsearch': PyDep(),
-                    'python-dateutil': PyDep(),
-                    'PyYaml': PyDep(),
-                    'requests': PyDep(),
-                    'wrapt': PyDep(),
-                    'Yapsy': PyDep(),
-                    'kafka-python': PyDep(),
-                    'urllib3': PyDep(),
-                    'six': PyDep(),
-                    'certifi': PyDep(),
-                    'chardet': PyDep(),
-                    'idna': PyDep(),
-                    'pytz': PyDep(),
-                    }
 
     def __init__(self):
         super(PyNuoCA, self).__init__(self.__PKGNAME)
@@ -45,9 +20,6 @@ class PyNuoCA(Package):
                              requirements='Python 2')]
         # There's only one, make it simple
         self.stage = self.staged[0]
-
-    def download(self):
-        pass
 
     def unpack(self):
         rmdir(self.pkgroot)

--- a/client/pkg/pynuoca.py
+++ b/client/pkg/pynuoca.py
@@ -14,6 +14,28 @@ class PyNuoCA(Package):
 
     __PKGNAME = 'pynuoca'
 
+    class PyDep:
+        _file = ""
+        _version = ""
+        _basedir = ""
+
+    dependencies = {'aenum': PyDep(),
+                    'click': PyDep(),
+                    'elasticsearch': PyDep(),
+                    'python-dateutil': PyDep(),
+                    'PyYaml': PyDep(),
+                    'requests': PyDep(),
+                    'wrapt': PyDep(),
+                    'Yapsy': PyDep(),
+                    'kafka-python': PyDep(),
+                    'urllib3': PyDep(),
+                    'six': PyDep(),
+                    'certifi': PyDep(),
+                    'chardet': PyDep(),
+                    'idna': PyDep(),
+                    'pytz': PyDep(),
+                    }
+
     def __init__(self):
         super(PyNuoCA, self).__init__(self.__PKGNAME)
         self._file = None
@@ -34,11 +56,29 @@ class PyNuoCA(Package):
                               pypi.pkgurl, chksum=pypi.pkgchksum)
         self._file.update()
 
+        for dependency_key, dependency_object in self.dependencies.items():
+            info('{}: Downloading dependency {}'.format(self.name, dependency_key))
+
+            dep = PyPIMetadata(dependency_key)
+
+            dependency_object._version = dep.version
+            dependency_object._file = Artifact(dependency_key,
+                                 '{}-{}.tar.gz'.format(dependency_key, dependency_object._version),
+                                 dep.pkgurl,
+                                 chksum=dep.pkgchksum)
+
+            dependency_object._file.update()
+
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
         unpack_file(self._file.path, self.pkgroot)
         self.stage.basedir = os.path.join(self.pkgroot, 'pynuoca-{}'.format(self.stage.version))
+
+        for dependency_key, dependency_object in self.dependencies.items():
+            info('{}: Unpacking dependency {}'.format(self.name, dependency_key))
+            unpack_file(dependency_object._file.path, self.pkgroot)
+            dependency_object._basedir = os.path.join(self.pkgroot, '{}-{}'.format(dependency_key, dependency_object._version))
 
     def install(self):
         self.stage.stage('python', ['pynuoca'])
@@ -46,6 +86,11 @@ class PyNuoCA(Package):
         self.stage.stage('doc', ['README.rst', 'LICENSE'])
         self.stage.stage('bin', ['bin/'])
         self.stage.stage('etc', ['etc/'])
+
+        for dependency_key, dependency_object in self.dependencies.items():
+            info('{}: Installing dependency {}'.format(self.name, dependency_key))
+            depdir = os.path.join('python', dependency_key)
+            self.stage.stage(depdir, [dependency_object._basedir+'/'])
 
 
 # Create and register this package

--- a/client/pkg/pynuoca.py
+++ b/client/pkg/pynuoca.py
@@ -47,51 +47,16 @@ class PyNuoCA(Package):
         self.stage = self.staged[0]
 
     def download(self):
-        # Find the latest release
-        pypi = PyPIMetadata(self.__PKGNAME)
-
-        self.setversion(pypi.version)
-
-        self._file = Artifact(self.name, 'pynuoca.tar.gz',
-                              pypi.pkgurl, chksum=pypi.pkgchksum)
-        self._file.update()
-
-        for dependency_key, dependency_object in self.dependencies.items():
-            info('{}: Downloading dependency {}'.format(self.name, dependency_key))
-
-            dep = PyPIMetadata(dependency_key)
-
-            dependency_object._version = dep.version
-            dependency_object._file = Artifact(dependency_key,
-                                 '{}-{}.tar.gz'.format(dependency_key, dependency_object._version),
-                                 dep.pkgurl,
-                                 chksum=dep.pkgchksum)
-
-            dependency_object._file.update()
+        pass
 
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
-        unpack_file(self._file.path, self.pkgroot)
-        self.stage.basedir = os.path.join(self.pkgroot, 'pynuoca-{}'.format(self.stage.version))
 
-        for dependency_key, dependency_object in self.dependencies.items():
-            info('{}: Unpacking dependency {}'.format(self.name, dependency_key))
-            unpack_file(dependency_object._file.path, self.pkgroot)
-            dependency_object._basedir = os.path.join(self.pkgroot, '{}-{}'.format(dependency_key, dependency_object._version))
+        run(['pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
 
     def install(self):
-        self.stage.stage('python', ['pynuoca'])
-        self.stage.stage('lib', ['lib/'])
-        self.stage.stage('doc', ['README.rst', 'LICENSE'])
-        self.stage.stage('bin', ['bin/'])
-        self.stage.stage('etc', ['etc/'])
-
-        for dependency_key, dependency_object in self.dependencies.items():
-            info('{}: Installing dependency {}'.format(self.name, dependency_key))
-            depdir = os.path.join('python', dependency_key)
-            self.stage.stage(depdir, [dependency_object._basedir+'/'])
-
+        self.stage.stage('python', ['./'])
 
 # Create and register this package
 PyNuoCA()

--- a/client/pkg/pynuoca.py
+++ b/client/pkg/pynuoca.py
@@ -2,6 +2,8 @@
 #
 # Add the nuodb collection agent
 
+import sys
+
 from client.package import Package
 from client.stage import Stage
 from client.utils import rmdir, mkdir, run
@@ -25,7 +27,7 @@ class PyNuoCA(Package):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
 
-        run(['pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
+        run([sys.executable, 'pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
 
     def install(self):
         self.stage.stage('python', ['./'])

--- a/client/pkg/pynuoca.py
+++ b/client/pkg/pynuoca.py
@@ -2,6 +2,8 @@
 #
 # Add the pynuoca module
 
+import os
+
 from client.package import Package
 from client.stage import Stage
 from client.artifact import GitHubMetadata, Artifact
@@ -37,12 +39,21 @@ class NuoCAPackage(Package):
         mkdir(self.pkgroot)
         unpack_file(self._zip.path, self.pkgroot)
 
-    def install(self):
-        self.stage.stage('jar', ['jar/'])
-        self.stage.stage('conf', ['conf/'])
-        ext = '' if Globals.target == 'lin64' else '.bat'
-        self.stage.stagefiles('bin', 'bin', ['nuodb-migrator'+ext])
+        for file_name in os.listdir(self.pkgroot):
+            self.stage.basedir = os.path.join(self.pkgroot, file_name)
 
+    def install(self):
+        if Globals.target != 'lin64':
+            info('{}: Skipping on {} platform'.format(self.name, Globals.target))
+            return
+
+        self.stage.stage(self.__PKGNAME, ['src/'])
+
+        self.stage.stage('etc', ['etc/'])
+        self.stage.stage('lib', ['lib/'])
+        self.stage.stage('plugins', ['plugins/'])
+
+        self.stage.stage('bin', ['bin/'])
 
 # Create and register this package
 NuoCAPackage()

--- a/client/pkg/pynuoca.py
+++ b/client/pkg/pynuoca.py
@@ -1,28 +1,28 @@
 # (C) Copyright NuoDB, Inc. 2019  All Rights Reserved.
 #
-# Add the nuodb-migrator client
+# Add the pynuoca module
 
 from client.package import Package
 from client.stage import Stage
 from client.artifact import GitHubMetadata, Artifact
 from client.utils import *
 
-class MigratorPackage(Package):
-    """Add the NuoDB migrator client."""
+class NuoCAPackage(Package):
+    """Add the NuoDB Collection Agent."""
 
-    __PKGNAME = 'migrator'
+    __PKGNAME = 'pynuoca'
 
     __USER = 'nuodb'
-    __REPO = 'migration-tools'
-    __ZIP = 'nuodb-migrator.zip'
+    __REPO = 'nuoca'
+    __ZIP = 'pynuoca.zip'
 
     def __init__(self):
-        super(MigratorPackage, self).__init__(self.__PKGNAME)
+        super(NuoCAPackage, self).__init__(self.__PKGNAME)
         self._zip = None
 
         self.staged = [Stage(self.__PKGNAME,
-                             title='NuoDB Migrator',
-                             requirements='Java 8 or 11')]
+                             title='NuoDB Collection Agent',
+                             requirements='Python 2')]
         self.stage = self.staged[0]
 
     def download(self):
@@ -45,4 +45,4 @@ class MigratorPackage(Package):
 
 
 # Create and register this package
-MigratorPackage()
+NuoCAPackage()

--- a/client/pkg/pynuoca.py
+++ b/client/pkg/pynuoca.py
@@ -1,59 +1,52 @@
-# (C) Copyright NuoDB, Inc. 2019  All Rights Reserved.
+# (C) Copyright NuoDB, Inc. 2020  All Rights Reserved.
 #
-# Add the pynuoca module
+# Add the nuodb collection agent
 
 import os
 
 from client.package import Package
 from client.stage import Stage
-from client.artifact import GitHubMetadata, Artifact
+from client.artifact import PyPIMetadata, Artifact
 from client.utils import *
 
-class NuoCAPackage(Package):
-    """Add the NuoDB Collection Agent."""
+class PyNuoCA(Package):
+    """Add the NuoDB Collection Agent"""
 
     __PKGNAME = 'pynuoca'
 
-    __USER = 'nuodb'
-    __REPO = 'nuoca'
-    __ZIP = 'pynuoca.zip'
-
     def __init__(self):
-        super(NuoCAPackage, self).__init__(self.__PKGNAME)
-        self._zip = None
+        super(PyNuoCA, self).__init__(self.__PKGNAME)
+        self._file = None
 
         self.staged = [Stage(self.__PKGNAME,
                              title='NuoDB Collection Agent',
                              requirements='Python 2')]
+        # There's only one, make it simple
         self.stage = self.staged[0]
 
     def download(self):
-        repo = GitHubMetadata(self.__USER, self.__REPO)
-        self.stage.version = repo.version
+        # Find the latest release
+        pypi = PyPIMetadata(self.__PKGNAME)
 
-        self._zip = Artifact(self.name, self.__ZIP, repo.pkgurl)
-        self._zip.update()
+        self.setversion(pypi.version)
+
+        self._file = Artifact(self.name, 'pynuoca.tar.gz',
+                              pypi.pkgurl, chksum=pypi.pkgchksum)
+        self._file.update()
 
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
-        unpack_file(self._zip.path, self.pkgroot)
-
-        for file_name in os.listdir(self.pkgroot):
-            self.stage.basedir = os.path.join(self.pkgroot, file_name)
+        unpack_file(self._file.path, self.pkgroot)
+        self.stage.basedir = os.path.join(self.pkgroot, 'pynuoca-{}'.format(self.stage.version))
 
     def install(self):
-        if Globals.target != 'lin64':
-            info('{}: Skipping on {} platform'.format(self.name, Globals.target))
-            return
-
-        self.stage.stage(self.__PKGNAME, ['src/'])
-
-        self.stage.stage('etc', ['etc/'])
+        self.stage.stage('python', ['pynuoca'])
         self.stage.stage('lib', ['lib/'])
-        self.stage.stage('plugins', ['plugins/'])
-
+        self.stage.stage('doc', ['README.rst', 'LICENSE'])
         self.stage.stage('bin', ['bin/'])
+        self.stage.stage('etc', ['etc/'])
+
 
 # Create and register this package
-NuoCAPackage()
+PyNuoCA()

--- a/client/pkg/pynuoca.py
+++ b/client/pkg/pynuoca.py
@@ -2,11 +2,9 @@
 #
 # Add the nuodb collection agent
 
-import sys
-
 from client.package import Package
 from client.stage import Stage
-from client.utils import rmdir, mkdir, run
+from client.utils import rmdir, mkdir, runpip
 
 class PyNuoCA(Package):
     """Add the NuoDB Collection Agent"""
@@ -26,8 +24,7 @@ class PyNuoCA(Package):
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
-
-        run([sys.executable, 'pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
+        runpip(self.__PKGNAME, self.pkgroot)
 
     def install(self):
         self.stage.stage('python', ['./'])

--- a/client/pkg/pynuodb.py
+++ b/client/pkg/pynuodb.py
@@ -2,11 +2,9 @@
 #
 # Add the nuodb-python client
 
-import sys
-
 from client.package import Package
 from client.stage import Stage
-from client.utils import rmdir, mkdir, run
+from client.utils import rmdir, mkdir, runpip
 
 
 class PyNuodbPackage(Package):
@@ -27,7 +25,7 @@ class PyNuodbPackage(Package):
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
-        run([sys.executable, 'pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
+        runpip(self.__PKGNAME, self.pkgroot)
 
     def install(self):
         self.stage.stage('python', ['./'])

--- a/client/pkg/pynuodb.py
+++ b/client/pkg/pynuodb.py
@@ -2,6 +2,8 @@
 #
 # Add the nuodb-python client
 
+import sys
+
 from client.package import Package
 from client.stage import Stage
 from client.utils import rmdir, mkdir, run
@@ -25,7 +27,7 @@ class PyNuodbPackage(Package):
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
-        run(['pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
+        run([sys.executable, 'pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
 
     def install(self):
         self.stage.stage('python', ['./'])

--- a/client/pkg/pynuodb.py
+++ b/client/pkg/pynuodb.py
@@ -25,24 +25,15 @@ class PyNuodbPackage(Package):
         self.stage = self.staged[0]
 
     def download(self):
-        # Find the latest release
-        pypi = PyPIMetadata(self.__PKGNAME)
-
-        self.setversion(pypi.version)
-
-        self._file = Artifact(self.name, 'pynuodb.tar.gz',
-                              pypi.pkgurl, chksum=pypi.pkgchksum)
-        self._file.update()
+        pass
 
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
-        unpack_file(self._file.path, self.pkgroot)
-        self.stage.basedir = os.path.join(self.pkgroot, 'pynuodb-{}'.format(self.stage.version))
+        run(['pip', 'install', self.__PKGNAME, '-t', self.pkgroot])
 
     def install(self):
-        self.stage.stage('python', ['pynuodb'])
-        self.stage.stage('doc', ['README.rst', 'LICENSE'])
+        self.stage.stage('python', ['./'])
 
 
 # Create and register this package

--- a/client/pkg/pynuodb.py
+++ b/client/pkg/pynuodb.py
@@ -2,12 +2,10 @@
 #
 # Add the nuodb-python client
 
-import os
-
 from client.package import Package
 from client.stage import Stage
-from client.artifact import PyPIMetadata, Artifact
-from client.utils import *
+from client.utils import rmdir, mkdir, run
+
 
 class PyNuodbPackage(Package):
     """Add the NuoDB nuodb-python client."""
@@ -23,9 +21,6 @@ class PyNuodbPackage(Package):
                              requirements='Python 2 or 3')]
         # There's only one, make it simple
         self.stage = self.staged[0]
-
-    def download(self):
-        pass
 
     def unpack(self):
         rmdir(self.pkgroot)

--- a/client/utils.py
+++ b/client/utils.py
@@ -4,7 +4,7 @@ __all__ = ['Globals', 'info', 'verbose', 'error',
            'mkdir', 'rmrf', 'rmdir', 'rmfile', 'rmfiles',
            'copy', 'copyinto', 'copyfiles', 'getcontents',
            'loadfile', 'savefile', 'unpack_file',
-           'which', 'runcmd', 'run', 'runout']
+           'which', 'runcmd', 'run', 'runout', 'runpip']
 
 import os
 import re
@@ -321,3 +321,7 @@ def runout(args, **kwargs):
         return (proc.wait(), out, err)
     except StandardError as ex:
         return (1, '', str(ex))
+
+
+def runpip(package_name, package_root):
+    return run([sys.executable, 'pip', '-m', 'install', package_name, '-t', package_root])

--- a/client/utils.py
+++ b/client/utils.py
@@ -324,4 +324,4 @@ def runout(args, **kwargs):
 
 
 def runpip(package_name, package_root):
-    return run([sys.executable, 'pip', '-m', 'install', package_name, '-t', package_root])
+    return run([sys.executable, '-m', 'pip', 'install', package_name, '-t', package_root])


### PR DESCRIPTION
Use `pip`, instead of tar downloads to get all dependencies for python based projects