### PR TITLE
Add ODBC driver to the client package, and cleanups

### DIFF
--- a/build
+++ b/build
@@ -8,6 +8,7 @@ Command-line tool for building the NuoDB client package.
 import os
 import sys
 import argparse
+import re
 
 from string import Template
 from datetime import datetime
@@ -18,7 +19,7 @@ from client.utils import Globals, info
 from client.utils import run, runout, mkdir, rmdir, rmfile, rmrf
 from client.utils import copyinto, copyfiles, loadfile, savefile
 
-# Import all packages
+# Import all packages.  This forces them to register themselves.
 from client.pkg import *
 
 # Also disable any per-user site-packages for safety
@@ -160,21 +161,34 @@ def main():
     parser.add_argument(
         'packages',
         metavar='PKGS',
-        default='all',
         nargs='*',
-        choices=['all']+packages,
         help='Packages to be built')
 
     options = parser.parse_args()
 
-    Globals.setup(isverbose=options.verbose,
-                  target=options.platform,
-                  buildid=options.build)
+    kwargs = {'isverbose': options.verbose,
+              'target': options.platform,
+              'buildid': options.build}
+
+    for arg in list(options.packages):
+        m = re.match(r'([^=]+)=([^\d].*)', arg)
+        if m is None:
+            if arg != 'all' and arg not in packages:
+                sys.exit("Invalid package '%s': must be one of:\n    all, %s"
+                         % (arg, ', '.join(packages)))
+        else:
+            kwargs[m.group(1)] = m.group(2)
+            options.packages.remove(arg)
+
+    if not options.packages:
+        options.packages = ['all']
+
+    Globals.setup(**kwargs)
 
     try:
         if options.clean or options.real_clean:
-            if options.packages == 'all':
-                info("Cleaning packages ...")
+            if 'all' in options.packages:
+                info("Cleaning all packages ...")
                 rmrf([Globals.tmproot, Globals.finalroot])
                 if options.real_clean:
                     info("Cleaning downloads ...")
@@ -186,7 +200,7 @@ def main():
                     pkg.clean(real=options.real_clean)
             return
 
-        if options.packages == 'all':
+        if 'all' in options.packages:
             options.packages = packages
 
         pkgname = build_clients(options.packages)

--- a/client/artifact.py
+++ b/client/artifact.py
@@ -29,8 +29,9 @@ __CONTEXT = None
 
 def _getremotedata(url):
     """Read a remote URL and return its data.
-       This is probably not efficient for large downloads..."""
 
+    This is probably not efficient for large downloads...
+    """
     global __CONTEXT
     if __CONTEXT is None:
         # Ignore cert: insecure but...
@@ -47,9 +48,13 @@ def _getremotedata(url):
         return remote.read()
 
     except HTTPError as ex:
-        raise DownloadError("HTTP Error: {}\nFailed reading {}".format(str(ex.reason), url))
+        msg = "HTTP Error: {}\nFailed reading {}".format(str(ex.reason), url)
+        verbose("Download failed: {}".format(msg))
+        raise DownloadError(msg)
     except URLError as ex:
-        raise DownloadError("URL Error: {}\nFailed reading {}".format(str(ex.reason), url))
+        msg = "URL Error: {}\nFailed reading {}".format(str(ex.reason), url)
+        verbose("Download failed: {}".format(msg))
+        raise DownloadError(msg)
     finally:
         if remote:
             remote.close()
@@ -121,8 +126,7 @@ class BaseArtifact(object):
         self.path = os.path.join(Globals.downloadroot, pkg, local)
 
     def get(self):
-        """Retrieve the artifact.
-           Subclasses implement this."""
+        """Retrieve the artifact.  Subclasses implement this."""
         raise NotImplementedError("get() is not implemented")
 
     def validate(self):
@@ -130,8 +134,7 @@ class BaseArtifact(object):
         return os.path.exists(self.path) and os.stat(self.path).st_size > 0
 
     def update(self):
-        """Get the artifact if it's not already available.
-           Users call this to retrieve artifacts."""
+        """Get the artifact if it's not already available."""
         if not self.validate():
             self.get()
 
@@ -211,7 +214,7 @@ class GitClone(BaseArtifact):
         self._run('clean', '-fdx')
         self._run('reset', '--hard')
 
-        # See if we want a SHA and of so, if it exists.  If so nothing to do.
+        # See if we want a SHA and if so, if it exists.  If so nothing to do.
         if re.match(r'[a-fA-F0-9]{5,40}$', self._ref):
             (ret, _, _) = runout([self._git, 'cat-file', '-e', self._ref+'^{commit}'], cwd=self.path)
             if ret == 0:

--- a/client/package.py
+++ b/client/package.py
@@ -116,6 +116,7 @@ class Package(object):
                 runstep('validate', self.validate)
                 runstep('unpack', self.unpack)
                 runstep('patch', self.patch)
+                runstep('make', self.make)
                 runstep('test', self.test)
 
             runstep('install', self.install)
@@ -129,8 +130,7 @@ class Package(object):
 
     @staticmethod
     def prereqs():
-        """Return a list of packages that need to be built before this one,
-           if they're going to be built."""
+        """Return a list of packages that need to be built before this one."""
         return []
 
     def clean(self, real=False):
@@ -160,14 +160,19 @@ class Package(object):
         """Apply any patches."""
         pass
 
+    def make(self):
+        """Perform any make operations."""
+        pass
+
     def test(self):
         """Run any tests."""
         pass
 
     def install(self):
         """Install the final package contents into self.distroot.
-           You can use the helper variables self.bindir, self.libdir, etc."""
 
+        You can use the helper variables self.bindir, self.libdir, etc.
+        """
         # Every package needs an install step
         raise NotImplementedError("install")
 

--- a/client/pkg/__init__.py
+++ b/client/pkg/__init__.py
@@ -1,2 +1,2 @@
-__all__ = ['nuodb', 'jdbc', 'migrator', 'hibernate', 'pynuodb', 'pynuoadmin',
-           'pynuoca']
+__all__ = ['nuodb', 'odbc', 'jdbc', 'migrator', 'hibernate',
+           'pynuodb', 'pynuoadmin', 'pynuoca']

--- a/client/pkg/hibernate.py
+++ b/client/pkg/hibernate.py
@@ -11,7 +11,7 @@ from client.utils import mkdir, rmdir, copy, savefile
 
 
 class HibernatePackage(Package):
-    """Add the NuoDB Hibernate (3 and 5) clients."""
+    """Add the NuoDB Hibernate 5 client."""
 
     __PKGNAME = 'hibernate'
 
@@ -20,57 +20,41 @@ class HibernatePackage(Package):
 
     def __init__(self):
         super(HibernatePackage, self).__init__(self.__PKGNAME)
-        self._hib3 = None
-        self._hib5 = None
+        self._hib = None
 
-        self.staged = [Stage(name='hibernate3',
-                             title='Hibernate3 Driver',
-                             requirements='Java 8 or 11'),
-
-                       Stage(name='hibernate5',
+        self.staged = [Stage(name='hibernate5',
                              title='Hibernate5 Driver',
                              requirements='Java 8 or 11')]
 
-        self.stage3 = self.staged[0]
-        self.stage5 = self.staged[1]
+        self.stage = self.staged[0]
 
     def download(self):
         # Hibernate is complicated because both versions 3 and 5 are released
         # in the same Maven repository.
         mvn = MavenMetadata(self.__PATH)
 
-        # Find the newest hib3 and hib5 versions
+        # Find the newest hib5 version
         for ver in mvn.metadata.find('versioning/versions'):
-            if ver.text.endswith('hib3'):
-                self.stage3.version = ver.text
-            elif ver.text.endswith('hib5'):
-                self.stage5.version = ver.text
+            if ver.text.endswith('hib5'):
+                self.stage.version = ver.text
 
-        self._hib3 = Artifact(self.name, 'nuodb-hibernate-hib3.jar',
-                              '{}/{}/{}'.format(mvn.baseurl, self.stage3.version,
-                                                self.__JAR.format(self.stage3.version)))
-
-        self._hib5 = Artifact(self.name, 'nuodb-hibernate-hib5.jar',
-                              '{}/{}/{}'.format(mvn.baseurl,
-                                                self.stage5.version, self.__JAR.format(self.stage5.version)))
+        self._hib = Artifact(self.name, 'nuodb-hibernate-hib5.jar',
+                             '{}/{}/{}'.format(mvn.baseurl,
+                                               self.stage.version,
+                                               self.__JAR.format(self.stage.version)))
 
         # We only download the actual jar files
-        self._hib3.update()
-        self._hib5.update()
+        self._hib.update()
 
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
-        copy(self._hib3.path, os.path.join(self.pkgroot, 'nuodb-hibernate-hib3.jar'))
-        copy(self._hib5.path, os.path.join(self.pkgroot, 'nuodb-hibernate-hib5.jar'))
+        copy(self._hib.path, os.path.join(self.pkgroot, 'nuodb-hibernate-hib5.jar'))
         savefile(os.path.join(self.pkgroot, 'LICENSE.txt'), self.getlicense('3BSD'))
 
     def install(self):
-        self.stage3.stage('jar', ['nuodb-hibernate-hib3.jar'])
-        self.stage3.stage('doc', ['LICENSE.txt'])
-
-        self.stage5.stage('jar', ['nuodb-hibernate-hib5.jar'])
-        self.stage5.stage('doc', ['LICENSE.txt'])
+        self.stage.stage('jar', ['nuodb-hibernate-hib5.jar'])
+        self.stage.stage('doc', ['LICENSE.txt'])
 
 
 # Create and register this package

--- a/client/pkg/jdbc.py
+++ b/client/pkg/jdbc.py
@@ -23,7 +23,7 @@ class JDBCPackage(Package):
         self._jar = None
 
         self.staged = [Stage('nuodbjdbc',
-                             title='JDBC Driver',
+                             title='NuoDB JDBC Driver',
                              requirements='Java 8 or 11')]
 
         self.stage = self.staged[0]

--- a/client/pkg/nuodb.py
+++ b/client/pkg/nuodb.py
@@ -41,10 +41,6 @@ class NuoDBPackage(Package):
                               title='nuodbmgr',
                               requirements='Java 8 or 11'),
 
-            'nuoodbc': Stage('nuoodbc',
-                             title='NuoODBC Driver',
-                             requirements='GNU/Linux with UnixODBC 2.3 or Windows'),
-
             'nuoremote': Stage('nuoremote',
                                title='C++ Driver',
                                requirements='GNU/Linux or Windows'),
@@ -107,13 +103,12 @@ class NuoDBPackage(Package):
         self.stgs['nuosql'].stagefiles('bin', 'bin', ['nuosql'])
         self.stgs['nuoloader'].stagefiles('bin', 'bin', ['nuoloader'])
 
-        self.stgs['nuoodbc'].stagefiles('lib64', 'lib64', ['libNuoODBC.so'])
         self.stgs['nuoremote'].stagefiles('lib64', 'lib64', ['libNuoRemote.so'])
         self.stgs['nuoclient'].stagefiles('lib64', 'lib64', ['libnuoclient.so'])
 
         # Add in shared libraries for packages that need it
         soglobs = ['libicu*.so.*', 'libmpir.so.*']
-        for stg in ['nuosql', 'nuoloader', 'nuoodbc', 'nuoremote', 'nuoclient']:
+        for stg in ['nuosql', 'nuoloader', 'nuoremote', 'nuoclient']:
             self.stgs[stg].stagefiles('lib64', 'lib64', soglobs)
 
         if 'nuodbmgr' in self.stgs:
@@ -126,7 +121,6 @@ class NuoDBPackage(Package):
         self.stgs['nuosql'].stagefiles('bin', 'bin', ['nuosql.exe'])
         self.stgs['nuoloader'].stagefiles('bin', 'bin', ['nuoloader.exe'])
 
-        self.stgs['nuoodbc'].stagefiles('bin', 'bin', ['NuoODBC.dll', 'NuoODBC.pdb'])
         self.stgs['nuoremote'].stagefiles('bin', 'bin', ['NuoRemote.dll', 'NuoRemote.pdb'])
         self.stgs['nuoremote'].stagefiles('lib', 'lib', ['NuoRemote.lib'])
         self.stgs['nuoclient'].stagefiles('bin', 'bin', ['nuoclient.dll', 'nuoclient.pdb'])
@@ -134,7 +128,7 @@ class NuoDBPackage(Package):
 
         # Add in shared libraries for packages that need it
         soglobs = ['icu*.dll', 'mpir*.dll', 'msvcp140.dll', 'vcruntime140.dll']
-        for stg in ['nuosql', 'nuoloader', 'nuoodbc', 'nuoremote', 'nuoclient']:
+        for stg in ['nuosql', 'nuoloader', 'nuoremote', 'nuoclient']:
             self.stgs[stg].stagefiles('bin', 'bin', soglobs)
 
         if 'nuodbmgr' in self.stgs:

--- a/client/pkg/odbc.py
+++ b/client/pkg/odbc.py
@@ -1,0 +1,138 @@
+# (C) Copyright NuoDB, Inc. 2022  All Rights Reserved.
+#
+# Add the NuoDB ODBC client
+
+import os
+import re
+
+from client.exceptions import CommandError
+from client.package import Package
+from client.stage import Stage
+from client.artifact import GitHubRepo
+from client.utils import Globals, rmdir, mkdir, which, run, runout
+
+
+class ODBCPackage(Package):
+    """Add the NuoDB ODBC client."""
+
+    __PKGNAME = 'odbc'
+
+    __USER = 'nuodb'
+    __REPO = 'nuodb-odbc'
+
+    # For now we just get the HEAD of the repo
+    __TAG = 'pds/updates'
+
+    def __init__(self):
+        super(ODBCPackage, self).__init__(self.__PKGNAME)
+        self._zip = None
+
+        self.staged = [Stage('nuodbodbc',
+                             title='NuoDB ODBC Driver',
+                             requirements='NuoDB C++ Driver; either UnixODBC 2.3 or Windows')]
+        self.stage = self.staged[0]
+
+    def prereqs(self):
+        # We need nuodb to get the C++ driver
+        return ['nuodb']
+
+    def download(self):
+        nm = '{}/{}'.format(self.__USER, self.__REPO)
+        self._repo = GitHubRepo(self.__USER, self.__REPO, nm, self.__TAG)
+        self._repo.update()
+
+    def make(self):
+        nuodb = self.get_package('nuodb')
+        self.distdir = os.path.join(self.stage.basedir, 'dist')
+        self.homedir = nuodb.staged[0].basedir
+
+        rmdir(self.pkgroot)
+        mkdir(self.pkgroot)
+        self.cmake = which('cmake')
+        if self.cmake is None:
+            raise CommandError("Cannot find cmake installed.")
+        args = [self.cmake, self._repo.path,
+                '-DCMAKE_BUILD_TYPE=RelWithDebInfo',
+                '-DNUODB_HOME={}'.format(self.homedir)]
+        args.append('-DCMAKE_INSTALL_PREFIX={}'.format(self.distdir))
+
+        if not Globals.iswindows:
+            incpath = os.environ.get('ODBC_INCLUDE')
+            if incpath is None and Globals.thirdparty_common:
+                incpath = os.path.join(Globals.thirdparty_common, 'unixODBC', 'include')
+            if incpath:
+                args.append('-DODBC_INCLUDE={}'.format(incpath))
+            libpath = os.environ.get('ODBC_LIB')
+            if libpath is None and Globals.thirdparty_arch:
+                libpath = os.path.join(Globals.thirdparty_arch, 'unixODBC', 'lib')
+            if libpath:
+                args.append('-DODBC_LIB={}'.format(libpath))
+
+        if Globals.cc:
+            args.append('-DCMAKE_C_COMPILER={}'.format(Globals.cc))
+        if Globals.cxx:
+            args.append('-DCMAKE_CXX_COMPILER={}'.format(Globals.cxx))
+
+        run(args, cwd=self.pkgroot)
+        run([self.cmake, '--build', '.', '--target', 'install'], cwd=self.pkgroot)
+
+    def test(self):
+        reports = os.path.join(self.stage.basedir, 'test-reports')
+        rmdir(reports)
+        admin = os.path.join(self.homedir, 'etc', 'nuoadmin')
+        nuocmd = os.path.join(self.homedir, 'bin', 'nuocmd')
+        if Globals.iswindows:
+            admin += '.bat'
+            nuocmd += '.bat'
+
+        os.environ['PATH'] = (os.path.join(self.homedir, 'bin')
+                              + os.pathsep + os.environ['PATH'])
+
+        # Disable TLS and start an AP
+        run([admin, 'tls', 'disable'])
+        run([admin, 'start'])
+        os.environ.pop('NUOCMD_CLIENT_KEY', None)
+        os.environ.pop('NUOCMD_VERIFY_SERVER', None)
+        try:
+            tscript = os.path.join(self._repo.path, 'etc', 'runtests')
+            tscript += '.bat' if Globals.iswindows else '.sh'
+            tbin = os.path.join(self.stage.basedir, 'test', 'NuoODBCTest')
+            run([tscript, self.distdir, tbin,
+                 '--gtest_output=xml:{}'.format(os.path.join(reports, 'NuoODBCTest-results.xml'))])
+        except Exception:
+            run([nuocmd, 'shutdown', 'database', '--db-name', 'NuoODBCTestDB'])
+            run([nuocmd, 'check', 'database', '--db-name', 'NuoODBCTestDB',
+                 '--num-processes', '0', '--timeout', '30'])
+            raise
+        finally:
+            try:
+                run([admin, 'stop'])
+            finally:
+                run([admin, 'tls', 'enable'])
+
+    def install(self):
+        # Once we've configured/built we can determine the version
+        verfile = os.path.join(self.stage.basedir, 'src', 'ProductVersion.h')
+        ver = {}
+        with open(verfile, 'r') as f:
+            for ln in f.readlines():
+                m = re.match(r'\s*#\s*define\s+NUOODBC_VERSION_([^\s]+)\s+(\d+)', ln)
+                if m:
+                    ver[m.group(1)] = m.group(2)
+        if len(ver) != 3:
+            raise CommandError("Version info not found in {}".format(verfile))
+        verstr = '{}.{}.{}'.format(ver['MAJOR'], ver['MINOR'], ver['MAINT'])
+        self.setversion(verstr)
+
+        if Globals.iswindows:
+            self.stage.stagefiles('lib', os.path.join(self.distdir, 'lib'),
+                                  ['NuoODBC.lib'])
+            self.stage.stagefiles('bin', os.path.join(self.distdir, 'bin'),
+                                  ['NuoODBC.dll', 'NuoODBC.pdb'])
+        else:
+            self.stage.stagefiles('lib64', os.path.join(self.distdir, 'lib64'),
+                                  ['libNuoODBC.so'])
+
+
+# Create and register this package
+ODBCPackage()


### PR DESCRIPTION
The ODBC driver needs to be compiled since we don't publish binary packages for it.  Add support for running cmake into the build.

Add support for GitHub projects as artifacts.
The latest versions of NuoDB don't provide old admin so remove nuodbmgr.
The latest versions of NuoDB don't use the -ce packages so don't assume they exist.

Remove obsolete Hibernate 3.