### PR TITLE
Update python version requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ requirements for running the NuoDB database are found in the NuoDB documentation
 +------------------+----------------------------------------+
 |nuodb-migrator    |Java 8 or 11                            |
 +------------------+----------------------------------------+
-|nuocmd            |Python 2.7 or 3.6                       |
+|nuocmd            |Python 3.6 or later                     |
 +------------------+----------------------------------------+
 |nuodbmgr          |Java 8 or 11                            |
 +------------------+----------------------------------------+


### PR DESCRIPTION
Since NuoDB v5.0.x we require python 3.6 or later to be installed in the OS. https://doc.nuodb.com/nuodb/latest/deployment-models/physical-or-vmware-environments-with-nuodb-admin/system-requirements/#_python