### PR TITLE
Use the correct python module when calling nuocmd command

### DIFF
--- a/bin/nuocmd
+++ b/bin/nuocmd
@@ -37,4 +37,4 @@ case $("$_python" --version 2>&1) in
 esac
 
 export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$_home/$_pkgdir"
-exec "$_python" -m pynuoadmin.nuodb_cli "$@"
+exec "$_python" -m pynuoadmin.nuocmd "$@"


### PR DESCRIPTION
nuocmd in client-only package will not allow NUOCMD_PLUGINS 
extension and will spit out a DeprecationWarning when invoked.
