### PR TITLE
Change version schema for the client package

### DIFF
--- a/build
+++ b/build
@@ -9,6 +9,7 @@ import os
 import sys
 import argparse
 import re
+import math
 
 from string import Template
 from datetime import datetime
@@ -38,8 +39,9 @@ PYTHONVERSION = 3
 
 
 def build_clients(packages):
-    version = datetime.now().strftime("%Y%m%d")
+    # build_number = os.getenv('build_number',1)
     buildid = Globals.buildid
+    version = "{}Q{}-{}".format(datetime.now().year, math.ceil(float(datetime.now().month)/3.), buildid)
     (ret, out, err) = runout(['git', 'rev-parse', '--short=10', 'HEAD'])
     commit = out if ret == 0 else 'UNK'
 


### PR DESCRIPTION
Use the format yyyyQq-b where

- yyyy = year
- q = quarter number
- b = build number

Example: 2023Q2-1