### PR TITLE
Make publishing easier and introduce bundles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,32 @@ Resources
 
 NuoDB Documentation_
 
+Building a client package
+-------------------------
+
+To build a client package, first clone this repository and ``cd`` into it. Then,
+decide on the version string you wish to use to identify this build of the client
+package (e.g., ``2023.1``). Then issue this command to download all the software
+included in the client package and bundle it::
+
+  $ ./build --version 2023.1
+
+The resulting bundle will be in the ``package`` directory::
+
+  $ ls -1 package/*.tar.gz
+  nuodb-tools-2023.1.lin-x64.tar.gz
+
+You may optionally build multiple bundles, one for CLI tools and one
+for drivers, by issuing this command::
+
+  $ ./build --separate-bundles --version 2023.1
+
+  $ ls -1 package/*.tar.gz
+  package/nuodb-cli-tools-2023.1.lin-x64.tar.gz
+  package/nuodb-drivers-2023.1.lin-x64.tar.gz
+
+Check ``./build --help`` for more options.
+
 License
 -------
 

--- a/build
+++ b/build
@@ -5,6 +5,48 @@
 Command-line tool for building the NuoDB client package.
 """
 
+# Package: Released (publicly downloadable) artifact (like nuodb)
+# Stage: Software within a package (like nuosql within nuodb)
+# Bundle: Convenience grouping of stages from 1 or more packages
+#
+# This tool produces one or more bundles that group together
+# stages as a convenience for users. Bundles group related stages
+# (like client tools or drivers) and all their dependencies into
+# a single tarball.
+#
+# Bundles are defined in the Bundles Enum in client.bundles.
+#
+# Package information describes how to download and unpack a
+# downloadable release. Packages are defined in client.pkg.*.
+# Every package defines at least one stage.
+#
+# Stages are defined in client.pkg.*. Each Stage is labeled
+# with a bundle when it is instantiated. A Stage's bundle determines
+# which tarball it ends up in.
+#
+# If you do not want to include a stage in a bundle explicitly,
+# set its bundle to None. A stage can still be pulled into a bundle
+# as a dependency, but it won't be put into a bundle otherwise.
+# A stage that is only pulled into a bundle as a dependency will
+# not be explicitly listed in the manifest.
+#
+# Every stage is labeled with a version, but currently we assume
+# that every stage in a package has the same version (the version
+# of the package).
+#
+# Bundles are versioned separately from any stage they contain.
+# You *must* specify a version to use for *every* bundle generated
+# in a single invocation of this build tool. A manifest will be
+# generated for each bundle, which will include the version of
+# each stage contained therein.
+#
+# By default all bundles are included in the same .tar.gz. The
+# manifest and README generators will use bundle information for
+# grouping stages together.
+#
+# To create one .tar.gz per bundle (.tar.gz name includes the
+# bundle name), pass the --separate-bundles option.
+
 import os
 import sys
 import argparse
@@ -12,6 +54,8 @@ import re
 
 from string import Template
 from datetime import datetime
+from collections import defaultdict
+from itertools import starmap
 
 from client.exceptions import ClientError
 from client.package import Package
@@ -36,40 +80,44 @@ GROUP = 'nuodb'
 
 PYTHONVERSION = 3
 
+DEFAULT_BUNDLE_NAME = 'tools'
 
-def build_clients(packages):
-    version = datetime.now().strftime("%Y%m%d")
-    buildid = Globals.buildid
-    (ret, out, err) = runout(['git', 'rev-parse', '--short=10', 'HEAD'])
-    commit = out if ret == 0 else 'UNK'
 
-    target = Globals.target
-    pkgname = 'nuodb-client-{}.{}'.format(version, target)
+def bundle_to_pkgname(bundle, target):
+    pkgname_template = 'nuodb-{}-{}.{}'
+    b = str(bundle) if Globals.separate_bundles else DEFAULT_BUNDLE_NAME
+    return pkgname_template.format(b, Globals.version, target)
 
-    # This is handled inside Package so it can deal with prerequisites etc.
-    Package.build_all(packages)
 
-    # Now construct the final package from all the individual dist directories
-    pkgdir = os.path.join(Globals.finalroot, pkgname)
-    rmdir(pkgdir)
-    mkdir(pkgdir)
-    staged = []
-    for pkgnm in packages:
-        pkg = Package.get_package(pkgnm)
-        info("Installing package {} ...".format(pkg.name))
-        for stg in pkg.staged:
-            staged.append(stg)
-            copyinto(stg.stagedir, pkgdir)
+def pkgname_to_pkgdir(pkgname):
+    return os.path.join(Globals.finalroot, pkgname)
 
-    manifest = []
-    packages = []
-    for stg in sorted(staged, key=lambda x: x.title):
-        manifest.append('  * {} version {}'.format(stg.title, stg.version))
+
+def build_readme(bundle_contents):
+    def stage_to_s(stg):
+        return '* {} version {} (bundled from: [{}]({}))'.format(
+            stg.title,
+            stg.version,
+            stg.repo_title,
+            stg.repo_url)
+    def bundle_to_s(title, stages):
+        return '### {}\n'.format(title) + '\n'.join(map(stage_to_s, stages))
+    readme = '\n\n'.join(starmap(bundle_to_s, bundle_contents.items())) + '\n'
+    savefile(os.path.join(Globals.finalroot, 'README.md'),
+             readme)
+
+
+def build_manifest(bundle_version, buildid, commit, pkgname, stages):
+    pkgdir = pkgname_to_pkgdir(pkgname)
+    stage_names = []
+    stage_notes = []
+    for stg in sorted(stages, key=lambda x: x.title):
+        stage_names.append('  * {} version {}'.format(stg.title, stg.version))
         if stg.notes is None:
             notes = ''
         else:
             notes = '\nNotes:{}'.format(stg.notes)
-        packages.append("""{}
+        stage_notes.append("""{}
 {}
 
 Version: {}
@@ -84,16 +132,66 @@ Contents:
                '\n  '.join(sorted(stg.getcontents()))))
 
     # Construct the various values for the README file
-    replace = {'VERSION': version,
+    replace = {'VERSION': bundle_version,
                'BUILD': buildid,
                'COMMIT': commit,
                'LICENSE': Package.getlicense('3BSD'),
-               'MANIFEST': '\n'.join(manifest),
-               'PACKAGES': '\n\n'.join(packages)}
+               'MANIFEST': '\n'.join(stage_names),
+               'PACKAGES': '\n\n'.join(stage_notes)}
 
     readme = loadfile('README.in')
     savefile(os.path.join(pkgdir, 'README.txt'),
              Template(readme).substitute(replace))
+
+
+def build_clients(packages):
+    buildid = Globals.buildid
+    (ret, out, err) = runout(['git', 'rev-parse', '--short=10', 'HEAD'])
+    commit = out if ret == 0 else 'UNK'
+
+    target = Globals.target
+
+    # This is handled inside Package so it can deal with prerequisites etc.
+    Package.build_all(packages)
+
+    # Track all package names to return later
+    pkgnames = set()
+
+    # We want to recreate each pkgdir when it is first used
+    pkgdir_cleaned = set()
+    def clean_pkgdir(d):
+        if d in pkgdir_cleaned:
+            return
+        rmdir(d)
+        mkdir(d)
+        pkgdir_cleaned.add(d)
+
+    # Now construct the final package from all the individual dist directories
+    #
+    # tarball_contents is used to build the per tarball README / manifest
+    # bundle_contents is used to build the overall README / manifest for the release notes
+    #
+    # If --separate-packages is set, then tarball_contents and bundle_contents will contain the same contents
+    tarball_contents = defaultdict(list)
+    bundle_contents = defaultdict(list)
+    for pkgnm in packages:
+        pkg = Package.get_package(pkgnm)
+
+        info("Installing package {} ...".format(pkg.name))
+        for stg in pkg.staged:
+            if stg.bundle is None:
+                continue
+            pkgname = bundle_to_pkgname(stg.bundle, target)
+            pkgnames.add(pkgname)
+            pkgdir = pkgname_to_pkgdir(pkgname)
+            clean_pkgdir(pkgdir)
+            copyinto(stg.stagedir, pkgdir)
+            tarball_contents[pkgname].append(stg)
+            bundle_contents[stg.bundle['title']].append(stg)
+
+    for pkgname, stages in tarball_contents.items():
+        build_manifest(Globals.version, buildid, commit, pkgname, stages)
+    build_readme(bundle_contents)
 
     etc = os.path.join(pkgdir, 'etc')
     mkdir(etc)
@@ -102,7 +200,7 @@ Contents:
     else:
         copyfiles(['nuodb_setup.bat'], Globals.etcdir, etc)
 
-    return pkgname
+    return pkgnames
 
 
 def create_package(pkgname):
@@ -128,10 +226,8 @@ def main():
     parser = argparse.ArgumentParser(description='Build the NuoDB Client package')
 
     parser.add_argument(
-        "-i",
-        "--info",
-        action="store_true",
-        help="Show information about known client packages")
+        '--version',
+        help='Version to use for each bundle')
 
     parser.add_argument(
         "-v",
@@ -167,6 +263,11 @@ def main():
         help="Clean previous builds and downloads.")
 
     parser.add_argument(
+        '--separate-bundles',
+        action='store_true',
+        help='Create a separate .tar.gz per bundle.')
+
+    parser.add_argument(
         'packages',
         metavar='PKGS',
         nargs='*',
@@ -174,9 +275,11 @@ def main():
 
     options = parser.parse_args()
 
-    kwargs = {'isverbose': options.verbose,
+    kwargs = {'version': options.version,
+              'isverbose': options.verbose,
               'target': options.platform,
-              'buildid': options.build}
+              'buildid': options.build,
+              'separate_bundles': options.separate_bundles}
 
     for arg in list(options.packages):
         m = re.match(r'([^=]+)=([^\d].*)', arg)
@@ -208,13 +311,17 @@ def main():
                     pkg.clean(real=options.real_clean)
             return
 
+        if options.version is None:
+            parser.error('Must specify --version to build packages')
+
         if 'all' in options.packages:
             options.packages = packages
 
-        pkgname = build_clients(options.packages)
+        pkgnames = build_clients(options.packages)
 
         if not options.no_package:
-            create_package(pkgname)
+            for pkgname in pkgnames:
+                create_package(pkgname)
 
     except ClientError as ex:
         sys.exit("Failed: {}".format(str(ex)))

--- a/client/bundles.py
+++ b/client/bundles.py
@@ -1,0 +1,15 @@
+# (C) Copyright NuoDB, Inc. 2023  All Rights Reserved.
+#
+# Enumerate the software bundles in the client package.
+#
+# Each stage must be associated with one bundle.
+
+from enum import Enum
+
+
+class Bundles(dict, Enum):
+    CLI_TOOLS = {'name': 'cli-tools', 'title': 'CLI tools'}
+    DRIVERS = {'name': 'drivers', 'title': 'Drivers'}
+
+    def __str__(self):
+        return self['name']

--- a/client/package.py
+++ b/client/package.py
@@ -1,4 +1,4 @@
-# (C) Copyright NuoDB, Inc. 2019  All Rights Reserved.
+# (C) Copyright NuoDB, Inc. 2019-2023  All Rights Reserved.
 #
 # Base class for creating a package in nuodb-client.
 # Each component in the client package should define a subclass of Package
@@ -95,6 +95,11 @@ class Package(object):
     def setversion(self, version):
         for stg in self.staged:
             stg.version = version
+
+    def set_repo(self, title, repo_url):
+        for stg in self.staged:
+            stg.repo_title = title
+            stg.repo_url = repo_url
 
     def build(self):
         assert not self.building

--- a/client/pkg/hibernate.py
+++ b/client/pkg/hibernate.py
@@ -1,4 +1,4 @@
-# (C) Copyright NuoDB, Inc. 2019  All Rights Reserved.
+# (C) Copyright NuoDB, Inc. 2019-2023  All Rights Reserved.
 #
 # Add the NuoDB hibernate clients
 
@@ -8,6 +8,7 @@ from client.package import Package
 from client.stage import Stage
 from client.artifact import MavenMetadata, Artifact
 from client.utils import mkdir, rmdir, copy, savefile
+from client.bundles import Bundles
 
 
 class HibernatePackage(Package):
@@ -24,7 +25,9 @@ class HibernatePackage(Package):
 
         self.staged = [Stage(name='hibernate5',
                              title='Hibernate5 Driver',
-                             requirements='Java 8 or 11')]
+                             requirements='Java 8 or 11',
+                             bundle=Bundles.DRIVERS,
+                             package=self.__PKGNAME)]
 
         self.stage = self.staged[0]
 
@@ -32,6 +35,7 @@ class HibernatePackage(Package):
         # Hibernate is complicated because both versions 3 and 5 are released
         # in the same Maven repository.
         mvn = MavenMetadata(self.__PATH)
+        self.set_repo(mvn.friendlytitle, mvn.friendlyurl)
 
         # Find the newest hib5 version
         for ver in mvn.metadata.find('versioning/versions'):

--- a/client/pkg/jdbc.py
+++ b/client/pkg/jdbc.py
@@ -1,4 +1,4 @@
-# (C) Copyright NuoDB, Inc. 2019  All Rights Reserved.
+# (C) Copyright NuoDB, Inc. 2019-2023  All Rights Reserved.
 #
 # Add the nuodb-jdbc client
 
@@ -8,6 +8,7 @@ from client.package import Package
 from client.stage import Stage
 from client.artifact import MavenMetadata, Artifact
 from client.utils import mkdir, rmdir, copy, savefile
+from client.bundles import Bundles
 
 
 class JDBCPackage(Package):
@@ -24,7 +25,9 @@ class JDBCPackage(Package):
 
         self.staged = [Stage('nuodbjdbc',
                              title='NuoDB JDBC Driver',
-                             requirements='Java 8 or 11')]
+                             requirements='Java 8 or 11',
+                             bundle=Bundles.DRIVERS,
+                             package=self.__PKGNAME)]
 
         self.stage = self.staged[0]
 
@@ -35,6 +38,7 @@ class JDBCPackage(Package):
     def download(self):
         # Find the latest release
         mvn = MavenMetadata(self.__PATH)
+        self.set_repo(mvn.friendlytitle, mvn.friendlyurl)
 
         self.setversion(mvn.version)
 

--- a/client/pkg/migrator.py
+++ b/client/pkg/migrator.py
@@ -1,4 +1,4 @@
-# (C) Copyright NuoDB, Inc. 2019  All Rights Reserved.
+# (C) Copyright NuoDB, Inc. 2019-2023  All Rights Reserved.
 #
 # Add the nuodb-migrator client
 
@@ -6,6 +6,7 @@ from client.package import Package
 from client.stage import Stage
 from client.artifact import GitHubMetadata, Artifact
 from client.utils import Globals, rmdir, mkdir, unpack_file
+from client.bundles import Bundles
 
 
 class MigratorPackage(Package):
@@ -22,12 +23,15 @@ class MigratorPackage(Package):
         self._zip = None
 
         self.staged = [Stage(self.__PKGNAME,
-                             title='NuoDB Migrator',
-                             requirements='Java 8 or 11')]
+                             title='NuoDB Migrator (nuodb-migrator)',
+                             requirements='Java 8 or 11',
+                             bundle=Bundles.CLI_TOOLS,
+                             package=self.__PKGNAME)]
         self.stage = self.staged[0]
 
     def download(self):
         repo = GitHubMetadata(self.__USER, self.__REPO)
+        self.set_repo(repo.friendlytitle, repo.friendlyurl)
         self.stage.version = repo.version
 
         self._zip = Artifact(self.name, self.__ZIP, repo.pkgurl)

--- a/client/pkg/nuocmd.py
+++ b/client/pkg/nuocmd.py
@@ -1,0 +1,34 @@
+# (C) Copyright NuoDB, Inc. 2023  All Rights Reserved.
+#
+# Add nuocmd
+
+import os
+import shutil
+
+from client.stage import Stage
+from client.bundles import Bundles
+from client.pkg.pynuoadmin import PyNuoadminPackage
+
+
+# nuocmd is installed by pynuoadmin, this is a trivial renaming in the manifest
+class NuocmdPackage(PyNuoadminPackage):
+    """Add the nuocmd client tool."""
+
+    __PKGNAME = 'nuocmd'
+
+    def __init__(self):
+        super(PyNuoadminPackage, self).__init__(self.__PKGNAME)
+
+        self._file = None
+        self._ac_file = None
+
+        self.staged = [Stage(self.__PKGNAME,
+                             title='nuocmd',
+                             requirements='Python 3',
+                             bundle=Bundles.TOOLS)]
+
+        self.stage = self.staged[0]
+
+
+# Create and register this package
+NuocmdPackage()

--- a/client/pkg/nuodb.py
+++ b/client/pkg/nuodb.py
@@ -1,4 +1,4 @@
-# (C) Copyright NuoDB, Inc. 2019  All Rights Reserved.
+# (C) Copyright NuoDB, Inc. 2019-2023  All Rights Reserved.
 #
 # Extract client content from the NuoDB database package
 
@@ -9,6 +9,7 @@ from client.package import Package
 from client.stage import Stage
 from client.artifact import Artifact
 from client.utils import Globals, mkdir, rmdir, loadfile, unpack_file, verbose
+from client.bundles import Bundles
 
 
 class NuoDBPackage(Package):
@@ -31,27 +32,40 @@ class NuoDBPackage(Package):
 
         self.stgs = {
             'nuosql': Stage('nuosql',
-                            title='nuosql',
-                            requirements='GNU/Linux or Windows'),
+                            title='NuoDB SQL (nuosql)',
+                            requirements='GNU/Linux or Windows',
+                            bundle=Bundles.CLI_TOOLS,
+                            package=self.__PKGNAME),
 
             'nuoloader': Stage('nuoloader',
-                               title='nuoloader',
-                               requirements='GNU/Linux or Windows'),
+                               title='NuoDB Loader (nuoloader)',
+                               requirements='GNU/Linux or Windows',
+                               bundle=Bundles.CLI_TOOLS,
+                               package=self.__PKGNAME),
 
             'nuodbmgr': Stage('nuodbmgr',
                               title='nuodbmgr',
-                              requirements='Java 8 or 11'),
+                              requirements='Java 8 or 11',
+                              bundle=Bundles.CLI_TOOLS,
+                              package=self.__PKGNAME),
 
             'nuoclient': Stage('nuoclient',
                                title='C Driver',
-                               requirements='GNU/Linux or Windows'),
+                               requirements='GNU/Linux or Windows',
+                               bundle=Bundles.DRIVERS,
+                               package=self.__PKGNAME),
 
             'nuoremote': Stage('nuoremote',
                                title='C++ Driver',
-                               requirements='GNU/Linux or Windows'),
+                               requirements='GNU/Linux or Windows',
+                               bundle=Bundles.DRIVERS,
+                               package=self.__PKGNAME),
+
             'nuodump': Stage('nuodump',
-                             title='NuoDB Logical Backup Tool',
-                             requirements='GNU/Linux or Windows')
+                             title='NuoDB Dump (nuodump)',
+                             requirements='GNU/Linux or Windows',
+                             bundle=Bundles.CLI_TOOLS,
+                             package=self.__PKGNAME)
         }
 
         self.staged = list(self.stgs.values())
@@ -90,6 +104,8 @@ class NuoDBPackage(Package):
                 self._pkg.update()
             except DownloadError:
                 raise ex
+
+        self.set_repo('NuoDB Server Package', self._pkg.url)
 
     def unpack(self):
         rmdir(self.pkgroot)

--- a/client/pkg/odbc.py
+++ b/client/pkg/odbc.py
@@ -1,4 +1,4 @@
-# (C) Copyright NuoDB, Inc. 2022  All Rights Reserved.
+# (C) Copyright NuoDB, Inc. 2022-2023  All Rights Reserved.
 #
 # Add the NuoDB ODBC client
 
@@ -9,6 +9,8 @@ from client.package import Package
 from client.stage import Stage
 from client.artifact import GitHubMetadata, Artifact
 from client.utils import Globals, rmdir, mkdir, unpack_file
+from client.bundles import Bundles
+
 
 class ODBCPackage(Package):
     """Add the NuoDB ODBC client."""
@@ -27,7 +29,9 @@ class ODBCPackage(Package):
 
         self.staged = [Stage('nuodbodbc',
                              title='NuoDB ODBC Driver',
-                             requirements='NuoDB C++ Driver; either UnixODBC 2.3 or Windows')]
+                             requirements='NuoDB C++ Driver; either UnixODBC 2.3 or Windows',
+                             bundle=Bundles.DRIVERS,
+                             package=self.__PKGNAME)]
         self.stage = self.staged[0]
 
     def _getext(self):
@@ -44,6 +48,7 @@ class ODBCPackage(Package):
 
     def download(self):
         repo = GitHubMetadata(self.__USER, self.__REPO)
+        self.set_repo(repo.friendlytitle, repo.friendlyurl)
         self.setversion(repo.version)
 
         ext = self._getext()

--- a/client/pkg/pynuoadmin.py
+++ b/client/pkg/pynuoadmin.py
@@ -1,4 +1,4 @@
-# (C) Copyright NuoDB, Inc. 2019-2020  All Rights Reserved.
+# (C) Copyright NuoDB, Inc. 2019-2023  All Rights Reserved.
 #
 # Add the pynuoadmin client
 
@@ -9,6 +9,7 @@ from client.artifact import PyPIMetadata
 from client.package import Package
 from client.stage import Stage
 from client.utils import Globals, getcontents, rmdir, mkdir, pipinstall
+from client.bundles import Bundles
 
 
 class PyNuoadminPackage(Package):
@@ -25,8 +26,10 @@ This pulls the latest version available from PyPI.
         self._ac_file = None
 
         self.staged = [Stage(self.__PKGNAME,
-                             title='NuoAdmin Driver',
-                             requirements='Python 3')]
+                             title='NuoAdmin Driver (pynuoadmin)',
+                             requirements='Python 3',
+                             bundle=Bundles.DRIVERS,
+                             package=self.__PKGNAME)]
 
         self.stage = self.staged[0]
 
@@ -36,6 +39,7 @@ This pulls the latest version available from PyPI.
 
     def unpack(self):
         pypi = PyPIMetadata(self.__PKGNAME)
+        self.set_repo(pypi.friendlytitle, pypi.friendlyurl)
         self.setversion(pypi.version)
 
         rmdir(self.pkgroot)

--- a/client/pkg/pynuoca.py
+++ b/client/pkg/pynuoca.py
@@ -1,4 +1,4 @@
-# (C) Copyright NuoDB, Inc. 2020  All Rights Reserved.
+# (C) Copyright NuoDB, Inc. 2020-2023  All Rights Reserved.
 #
 # Add the nuodb collection agent
 
@@ -31,6 +31,7 @@ class PyNuoCA(Package):
 
     def unpack(self):
         pypi = PyPIMetadata(self.__PKGNAME)
+        self.set_repo(pypi.friendlytitle, pypi.friendlyurl)
         self.setversion(pypi.version)
 
         rmdir(self.pkgroot)

--- a/client/pkg/pynuodb.py
+++ b/client/pkg/pynuodb.py
@@ -1,4 +1,4 @@
-# (C) Copyright NuoDB, Inc. 2019  All Rights Reserved.
+# (C) Copyright NuoDB, Inc. 2019-2023  All Rights Reserved.
 #
 # Add the nuodb-python client
 
@@ -9,6 +9,7 @@ from client.artifact import PyPIMetadata
 from client.package import Package
 from client.stage import Stage
 from client.utils import rmdir, mkdir, pipinstall, getcontents
+from client.bundles import Bundles
 
 
 class PyNuodbPackage(Package):
@@ -21,8 +22,10 @@ class PyNuodbPackage(Package):
         self._file = None
 
         self.staged = [Stage(self.__PKGNAME,
-                             title='Python Driver',
+                             title='Python Driver (pynuodb)',
                              requirements='Python 2 or 3',
+                             bundle=Bundles.DRIVERS,
+                             package=self.__PKGNAME,
                              notes="""
     For improved performance, install the Python cryptography package:
         python -m pip install cryptography
@@ -32,6 +35,7 @@ class PyNuodbPackage(Package):
 
     def unpack(self):
         pypi = PyPIMetadata(self.__PKGNAME)
+        self.set_repo(pypi.friendlytitle, pypi.friendlyurl)
         self.setversion(pypi.version)
 
         rmdir(self.pkgroot)

--- a/client/stage.py
+++ b/client/stage.py
@@ -1,11 +1,11 @@
-# (C) Copyright NuoDB, Inc. 2019  All Rights Reserved.
+# (C) Copyright NuoDB, Inc. 2019-2023  All Rights Reserved.
 
 import os
 import json
 
 from client.utils import Globals, loadfile, savefile, getcontents
 from client.utils import mkdir, rmdir, rmfile, copy, copyinto
-
+from client.bundles import Bundles
 
 class Stage(object):
     """Class representing the staged content of a client."""
@@ -26,11 +26,13 @@ class Stage(object):
     # Any files here will be added to the generated results
     extracontents = None
 
-    def __init__(self, name, title=None, requirements=None, notes=None):
+    def __init__(self, name, title=None, requirements=None, notes=None, bundle=None, package=None):
         self.name = name
         self.title = title
         self.requirements = requirements
         self.notes = notes
+        self.bundle = bundle
+        self.package = package
         self._staged = []
         self.omitcontents = []
         self.extracontents = []


### PR DESCRIPTION
= Generate README.md

Generate package/README.md which can be copy/pasted into the release notes on GitHub when generating a new client package release.

This ensures that we list the correct version of each software artifact included in the package, and lists the packages in a categorized way to improve readability (see below).

= Introduce the concept of a "bundle"

The client package is composed of software extracted from _packages_.

Each package consists of one or more _stages_.

Each _stage_ describes a software artifact that can be extracted from its downloaded package.

Each _stage_ is associated with exactly one _bundle_, which categorizes the type of software provided by the _stage_ (e.g., a CLI tool).

Bundles are used in the following ways:

* Categorize each stage in the new README.md

* If the option --separate-bundles is supplied, one tarball per bundle will be generated (instead of the default which stores all stages together into one tarball).

See comments in build and bundles defined in client/bundles.py.

= Add argument --version

Instead of auto-generating a version from the current date, the user must now supply the version to use with the --version argument.

This avoids the problem where the next version number is communicated but then the actual package is built on a different day.

= Add argument --separate-bundles

By default, one tarball called nuodb-tools-{version}.{arch}.tar.gz is created. This package contains the software artifacts from all stages.

If --separate-bundles is supplied, then one tarball is created _per bundle_. Each tarball contains only the software artifacts from the stages associated with that bundle.

For example, given the stages and bundles defined as of this commit, building for Linux without --separate-bundles produces this:

  $ ./build --clean ; ./build --version 2023.1
  $ ls -1 package/*.tar.gz
  package/nuodb-tools-2023.1.lin-x64.tar.gz

whereas building _with_ --separate-bundles produces this:

  $ ./build --clean ; ./build --version 2023.1 --separate-bundles
  $ ls -1 package/*.tar.gz
  package/nuodb-cli-tools-2023.1.lin-x64.tar.gz
  package/nuodb-drivers-2023.1.lin-x64.tar.gz

= Other

* Some trivial renaming of stages.

* Updated the GitHub README.rst with instructions for building a client package yourself.

* Added support for a "friendly URL" for each package so that a link to a stage's GitHub / Maven Central / PyPi / etc. page can be provided in the generated README.md.