### PR TITLE
Fix error when building the client package

### DIFF
--- a/client/stage.py
+++ b/client/stage.py
@@ -36,6 +36,8 @@ class Stage(object):
         self._staged = []
         self.omitcontents = []
         self.extracontents = []
+        self.repo_title = ""
+        self.repo_url = ""
 
     def setup(self, basedir):
         stgroot = Globals.stageroot


### PR DESCRIPTION
When building the package for the second time,
an error pops up complaining about missing
attributes on the stage class.
Initializing the attributes fixes the error.