### PR TITLE
Change the default bundle name back to 'client'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ jobs:
           name: "Build Linux package"
           command: |
             python ./build -v -p lin-x64 --version "${CIRCLE_BUILD_NUM}"
-            cp package/nuodb-tools-${CIRCLE_BUILD_NUM}.lin-x64.tar.gz package/nuodb-tools.lin-x64.tar.gz
+            cp package/nuodb-client-${CIRCLE_BUILD_NUM}.lin-x64.tar.gz package/nuodb-client.lin-x64.tar.gz
       - store_artifacts:
-          path: package/nuodb-tools.lin-x64.tar.gz
+          path: package/nuodb-client.lin-x64.tar.gz
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/configuration-reference/#workflows

--- a/build
+++ b/build
@@ -80,7 +80,7 @@ GROUP = 'nuodb'
 
 PYTHONVERSION = 3
 
-DEFAULT_BUNDLE_NAME = 'tools'
+DEFAULT_BUNDLE_NAME = 'client'
 
 
 def bundle_to_pkgname(bundle, target):


### PR DESCRIPTION
After some discussion, it has been agreed tha we
would keep the same bundle name

nuodb-client-[VERSION].[OS].[EXTENSION]