### PR TITLE
Fix issue on nuocmd when python 3.6 is installed

### DIFF
--- a/bin/nuocmd
+++ b/bin/nuocmd
@@ -18,6 +18,10 @@ if test -z "$_python"; then
     _python=$(command -v python3) \
         || _python=$(command -v python) \
         || die "Python must be installed"
+    _python_version="$($_python --version)"
+    if [[ "$_python_version" == *"3.6"* ]]; then
+        die "$_python_version not supported. Please use python version 3.7 or above."
+    fi
 fi
 
 # Find the pynuoadmin installation


### PR DESCRIPTION
The urllib3 and requests module does not support python v3.6 so we need to check for the version of python3 installed in the system.
If it is, gracefully exits with a message.