### PR TITLE
Add separate bundles for the C and C++ drivers

### DIFF
--- a/client/bundles.py
+++ b/client/bundles.py
@@ -9,7 +9,9 @@ from enum import Enum
 
 class Bundles(dict, Enum):
     CLI_TOOLS = {'name': 'cli-tools', 'title': 'CLI tools'}
-    DRIVERS = {'name': 'drivers', 'title': 'Drivers'}
+    DRIVERS = {'name': 'other-drivers', 'title': 'Other drivers'}
+    DRIVER_C = {'name': 'c-driver', 'title': 'C driver'}
+    DRIVER_CPP = {'name': 'cpp-driver', 'title':'C++ driver'}
 
     def __str__(self):
         return self['name']

--- a/client/pkg/nuodb.py
+++ b/client/pkg/nuodb.py
@@ -52,13 +52,13 @@ class NuoDBPackage(Package):
             'nuoclient': Stage('nuoclient',
                                title='C Driver',
                                requirements='GNU/Linux or Windows',
-                               bundle=Bundles.DRIVERS,
+                               bundle=Bundles.DRIVER_C,
                                package=self.__PKGNAME),
 
             'nuoremote': Stage('nuoremote',
                                title='C++ Driver',
                                requirements='GNU/Linux or Windows',
-                               bundle=Bundles.DRIVERS,
+                               bundle=Bundles.DRIVER_CPP,
                                package=self.__PKGNAME),
 
             'nuodump': Stage('nuodump',


### PR DESCRIPTION
Add separate bundles for the C and C++ drivers.

Rename the drivers bundle to "Other drivers". This can be ignored. A future commit should add the option to ignore a stage when building separate bundles.

The CLI bundle remains unchanged.

The combined bundle ("classic" client package) also remains unchanged.

Here are the bundles that get built with this commit:

```
$ ./build --separate-bundles --version 12345

$ ls -1 package/*.tar.gz
package/nuodb-c-driver-12345.lin-x64.tar.gz
package/nuodb-cli-tools-12345.lin-x64.tar.gz
package/nuodb-cpp-driver-12345.lin-x64.tar.gz
package/nuodb-other-drivers-12345.lin-x64.tar.gz
```