### PR TITLE
Update NuoDB package script to use Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,7 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.14
+      - setup_remote_docker
       - run:
           name: "Build Linux package"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,16 @@ version: 2.1
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/configuration-reference/#jobs
 jobs:
-  build-linux:
-    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/configuration-reference/#executor-job
-    docker:
-      - image: cimg/python:3.11.4
-    resource_class: small
+   build-linux:
+     # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
+     # See: https://circleci.com/docs/configuration-reference/#executor-job
+     docker:
+       - image: cimg/python:3.11.4
+     resource_class: small
+     # Enable Docker-in-Docker for running Docker commands
+     # See: https://circleci.com/docs/building-docker-images
+     setup_remote_docker:
+       version: 20.10.14
     # Add steps to the job
     # See: https://circleci.com/docs/configuration-reference/#steps
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,21 @@
 version: 2.1
 
 jobs:
-   build-linux:
-     docker:
-       - image: cimg/python:3.11.4
-     resource_class: small
-     setup_remote_docker:
-       version: 20.10.14
-     steps:
-       - checkout
-       - run:
-           name: "Build Linux package"
-           command: |
-             python ./build -v -p lin-x64 --version "${CIRCLE_BUILD_NUM}"
-             cp package/nuodb-client-${CIRCLE_BUILD_NUM}.lin-x64.tar.gz package/nuodb-client.lin-x64.tar.gz
-       - store_artifacts:
-           path: package/nuodb-client.lin-x64.tar.gz
+  build-linux:
+    docker:
+      - image: cimg/python:3.11.4
+    resource_class: small
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.14
+      - run:
+          name: "Build Linux package"
+          command: |
+            python ./build -v -p lin-x64 --version "${CIRCLE_BUILD_NUM}"
+            cp package/nuodb-client-${CIRCLE_BUILD_NUM}.lin-x64.tar.gz package/nuodb-client.lin-x64.tar.gz
+      - store_artifacts:
+          path: package/nuodb-client.lin-x64.tar.gz
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,22 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/configuration-reference
 version: 2.1
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/configuration-reference/#jobs
 jobs:
    build-linux:
-     # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-     # See: https://circleci.com/docs/configuration-reference/#executor-job
      docker:
        - image: cimg/python:3.11.4
      resource_class: small
-     # Enable Docker-in-Docker for running Docker commands
-     # See: https://circleci.com/docs/building-docker-images
      setup_remote_docker:
        version: 20.10.14
-    # Add steps to the job
-    # See: https://circleci.com/docs/configuration-reference/#steps
-    steps:
-      - checkout
-      - run:
-          name: "Build Linux package"
-          command: |
-            python ./build -v -p lin-x64 --version "${CIRCLE_BUILD_NUM}"
-            cp package/nuodb-client-${CIRCLE_BUILD_NUM}.lin-x64.tar.gz package/nuodb-client.lin-x64.tar.gz
-      - store_artifacts:
-          path: package/nuodb-client.lin-x64.tar.gz
+     steps:
+       - checkout
+       - run:
+           name: "Build Linux package"
+           command: |
+             python ./build -v -p lin-x64 --version "${CIRCLE_BUILD_NUM}"
+             cp package/nuodb-client-${CIRCLE_BUILD_NUM}.lin-x64.tar.gz package/nuodb-client.lin-x64.tar.gz
+       - store_artifacts:
+           path: package/nuodb-client.lin-x64.tar.gz
 
-# Orchestrate jobs using workflows
-# See: https://circleci.com/docs/configuration-reference/#workflows
 workflows:
   build:
     jobs:

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,14 @@ To build a client package, first clone this repository and ``cd`` into it. Then,
 decide on the version string to use to identify this build of the client
 package (e.g., ``2025.3``).
 
+By default, the build extracts NuoDB client files from the ``nuodb/nuodb:latest``
+Docker image. To build from a specific NuoDB image tag or digest, pass
+``nuodb_image=...`` after the regular build options::
+
+  $ ./build --version 2025.3 nuodb_image=nuodb/nuodb:2025.3.0
+
+  $ ./build --version 2025.3 nuodb_image=nuodb/nuodb@sha256:<digest>
+
 By default, a single package is generated that includes all the drivers and
 tools. To build this package, issue this command::
 

--- a/client/pkg/nuodb.py
+++ b/client/pkg/nuodb.py
@@ -3,12 +3,13 @@
 # Extract client content from the NuoDB database package
 
 import os
+import subprocess
 
 from client.exceptions import DownloadError, UnpackError
 from client.package import Package
 from client.stage import Stage
 from client.artifact import Artifact
-from client.utils import Globals, mkdir, rmdir, loadfile, unpack_file, verbose
+from client.utils import Globals, mkdir, rmdir, loadfile, unpack_file, verbose, run, runout, copyinto
 from client.bundles import Bundles
 
 
@@ -16,14 +17,6 @@ class NuoDBPackage(Package):
     """Extract NuoDB clients from the database package."""
 
     __PKGNAME = 'nuodb'
-
-    __NUODB_URL = 'https://ce-downloads.nuohub.org'
-    __VERSIONS = 'supportedversions.txt'
-    __LINX64FORMAT = 'nuodb-{}.linux.x86_64'
-    __LINARM64FORMAT = 'nuodb-{}.linux.arm64'
-    __TAREXT = '.tar.gz'
-    __ZIPFORMAT = 'nuodb-{}.win64'
-    __ZIPEXT = '.zip'
 
     def __init__(self):
         super(NuoDBPackage, self).__init__(self.__PKGNAME)
@@ -70,47 +63,51 @@ class NuoDBPackage(Package):
         self.staged = list(self.stgs.values())
 
     def download(self):
-        versions = Artifact(self.name, self.__VERSIONS,
-                            '{}/{}'.format(self.__NUODB_URL, self.__VERSIONS))
-        versions.get()
+        # Use Docker to pull the NuoDB image and extract files
+        docker_image = 'nuodb/nuodb:latest'
+        verbose(f"Pulling Docker image: {docker_image}")
 
-        version = loadfile(versions.path).split()[-1]
-        self.setversion(version)
+        # Pull the Docker image
+        (ret, out, err) = runout(['docker', 'pull', docker_image])
+        if ret != 0:
+            raise DownloadError(f"Failed to pull Docker image {docker_image}: {err}")
 
-        if Globals.target == 'lin-x64':
-            fmt = self.__LINX64FORMAT
-            ext = self.__TAREXT
-        elif Globals.target == 'lin-arm64':
-            fmt = self.__LINARM64FORMAT
-            ext = self.__TAREXT
-        else:
-            fmt = self.__ZIPFORMAT
-            ext = self.__ZIPEXT
+        # Create a temporary container to extract files
+        container_name = 'nuodb-extract'
+        verbose(f"Creating temporary container: {container_name}")
+        (ret, out, err) = runout(['docker', 'create', '--name', container_name, docker_image])
+        if ret != 0:
+            raise DownloadError(f"Failed to create container {container_name}: {err}")
 
-        try:
-            self._dirname = fmt.format(version)
-            pkgname = self._dirname + ext
-            self._pkg = Artifact(self.name, pkgname,
-                                 '{}/{}'.format(self.__NUODB_URL, pkgname))
-            self._pkg.update()
-        except DownloadError as ex:
-            # Older releases publish packages named with a "ce" label; try that
-            try:
-                self._dirname = fmt.format('ce-'+version)
-                pkgname = self._dirname + ext
-                self._pkg = Artifact(self.name, pkgname,
-                                     '{}/{}'.format(self.__NUODB_URL, pkgname))
-                self._pkg.update()
-            except DownloadError:
-                raise ex
+        # Extract files from the container
+        extract_path = os.path.join(Globals.downloadroot, self.name)
+        mkdir(extract_path)
+        verbose(f"Extracting files to: {extract_path}")
+        (ret, out, err) = runout(['docker', 'cp', f'{container_name}:/opt/nuodb', extract_path])
+        if ret != 0:
+            raise DownloadError(f"Failed to extract files from container: {err}")
 
-        self.set_repo('NuoDB Server Package', self._pkg.url)
+        # Clean up the container
+        verbose(f"Removing temporary container: {container_name}")
+        run(['docker', 'rm', '-f', container_name])
+
+        # Set the version and package details
+        self._dirname = 'nuodb'
+        self._pkg = Artifact(self.name, 'nuodb-extracted', extract_path)
+        self._pkg.path = extract_path
+        self.setversion('latest')
+        self.set_repo('NuoDB Docker Image', docker_image)
 
     def unpack(self):
         rmdir(self.pkgroot)
         mkdir(self.pkgroot)
-        unpack_file(self._pkg.path, self.pkgroot)
+
+        # Copy extracted files to pkgroot
+        src_path = self._pkg.path
         udir = os.path.join(self.pkgroot, self._dirname)
+        mkdir(udir)
+        copyinto(src_path, udir)
+
         if not os.path.exists(udir):
             raise UnpackError("Unpack did not create %s" % (udir))
 

--- a/client/pkg/nuodb.py
+++ b/client/pkg/nuodb.py
@@ -64,7 +64,7 @@ class NuoDBPackage(Package):
 
     def download(self):
         # Use Docker to pull the NuoDB image and extract files
-        docker_image = 'nuodb/nuodb:latest'
+        docker_image = getattr(Globals, 'nuodb_image', 'nuodb/nuodb:latest')
         verbose(f"Pulling Docker image: {docker_image}")
 
         # Pull the Docker image


### PR DESCRIPTION
This commit updates the NuoDB package script to fetch and extract files from the official NuoDB Docker image instead of downloading packages from the S3 endpoint. This change addresses the removal of public access to NuoDB packages on S3 and leverages the Docker image as the new distribution method.

Key Changes:
- Removed dependencies on the S3 endpoint and the`supportedversions.txt` file.
- Added Docker support to pull the `nuodb/nuodb:latest` image and extract files.
- Updated the `download` method to use Docker commands for pulling the image and extracting files from the container.
- Modified the `unpack` method to copy files from the extracted Docker image to the package root directory.
- Removed unused constants related to the S3 URL and package formats.

This change ensures that the NuoDB client package can still be built and distributed without relying on the deprecated S3 endpoint.